### PR TITLE
Test automerge functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ You can support `prettier/plugin-ruby` [on OpenCollective](https://opencollectiv
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
 
+Alter ego automerge test
+
 ## License
 
 The package is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
If 057a42ee1754dde6694b1e512d0226ba0206f97d works as expected, then the same automerge functionality should work for dependabot as specified in https://github.com/prettier/plugin-ruby/pull/880